### PR TITLE
feat(dynamodb): add select input for table names

### DIFF
--- a/packages/cli/src/commands/dynamodb/purge.ts
+++ b/packages/cli/src/commands/dynamodb/purge.ts
@@ -65,23 +65,27 @@ const getParameters = (toolbox: GluegunToolbox): Observable<Parameters> => {
       })),
       mergeObj<Table, string>(
         () =>
-          input.str({
-            argumentName: 'first',
-            message: 'Table name:',
-          }),
-        (orig, tableName) => ({
-          ...orig,
-          tableName,
-        })
-      ),
-      mergeObj<Table, string>(
-        () =>
           aws.region({
             defaultValue: 'eu-central-1',
           }),
         (orig, region) => ({
           ...orig,
           region,
+        })
+      ),
+      mergeObj<Table, string>(
+        (table) =>
+          aws.tableName({
+            region: table.region,
+            credentials: {
+              accessKeyId: table.accessKeyId,
+              secretAccessKey: table.secretAccessKey,
+            },
+            parameter: `first`,
+          }),
+        (orig, tableName) => ({
+          ...orig,
+          tableName,
         })
       )
     )

--- a/packages/cli/src/commands/dynamodb/sync.ts
+++ b/packages/cli/src/commands/dynamodb/sync.ts
@@ -23,7 +23,7 @@ const command: GluegunCommand = {
 }
 
 const getParameters = (toolbox: GluegunToolbox): Observable<Paramaters> => {
-  const { aws, input } = toolbox
+  const { aws } = toolbox
 
   const getCredentials = (
     optionPrefix: string,
@@ -88,21 +88,25 @@ const getParameters = (toolbox: GluegunToolbox): Observable<Paramaters> => {
         secretAccessKey: credentials.secretAccessKey,
       })),
       mergeObj<Table, string>(
-        () =>
-          input.str({
-            argumentName: `${optionPrefix}TableName`,
-            message: `${labelPrefix} Table Name:`,
-          }),
-        (orig, tableName) => ({
-          ...orig,
-          tableName,
-        })
-      ),
-      mergeObj<Table, string>(
         () => getRegion(optionPrefix, labelPrefix),
         (orig, region) => ({
           ...orig,
           region,
+        })
+      ),
+      mergeObj<Table, string>(
+        (table) =>
+          aws.tableName({
+            region: table.region,
+            credentials: {
+              accessKeyId: table.accessKeyId,
+              secretAccessKey: table.secretAccessKey,
+            },
+            parameter: `${optionPrefix}TableName`,
+          }),
+        (orig, tableName) => ({
+          ...orig,
+          tableName,
         })
       )
     )

--- a/packages/cli/src/extensions/aws-extension.ts
+++ b/packages/cli/src/extensions/aws-extension.ts
@@ -119,7 +119,7 @@ module.exports = (toolbox: GluegunToolbox) => {
 
   const promptTableName = (
     labelPrefix: string,
-    credentials: Credentials,
+    credentials: Record<'accessKeyId' | 'secretAccessKey', string>,
     region: string
   ): Observable<string> => {
     labelPrefix = labelPrefix ? labelPrefix + ' ' : ''
@@ -271,7 +271,10 @@ interface RegionOptions {
 interface TableNameOptions {
   parameter?: string
   labelPrefix?: string
-  credentials?: Credentials
+  credentials?: {
+    accessKeyId: string
+    secretAccessKey: string
+  }
   region?: string
   interactive?: boolean
 }

--- a/packages/cli/src/extensions/aws-extension.ts
+++ b/packages/cli/src/extensions/aws-extension.ts
@@ -2,19 +2,25 @@ import { GluegunToolbox } from 'gluegun'
 import { combineLatest, from, Observable, of, throwError } from 'rxjs'
 import { Credentials, SharedIniFileCredentials, IniLoader } from 'aws-sdk'
 import * as deepmerge from 'deepmerge'
-import { map, switchMap } from 'rxjs/operators'
+import { catchError, map, switchMap } from 'rxjs/operators'
 import { PromptOptions } from 'gluegun/build/types/toolbox/prompt-enquirer-types'
+import { DynamoDBClient } from '@immowelt/awsk-dynamodb'
 
 export interface AWSToolboxExtension {
   credentials: (options?: CredentialOptions) => Observable<Credentials>
   credentialsChain: (...options: CredentialOptions[]) => Observable<Credentials>
   region: (options?: RegionOptions) => Observable<string>
   regionChain: (...options: RegionOptions[]) => Observable<string>
+  tableName: (options?: TableNameOptions) => Observable<string>
+  tableNameChain: (...options: TableNameOptions[]) => Observable<string>
 }
 
 module.exports = (toolbox: GluegunToolbox) => {
   const { parameters, print, prompt } = toolbox
 
+  const hasArgument = (name: string): boolean =>
+    name in parameters && !!getArgumentValue(name)
+  const getArgumentValue = (name: string): string => parameters[name]
   const hasOption = (name: string): boolean => name in parameters.options
   const getOptionValue = (name: string): string => parameters.options[name]
 
@@ -26,12 +32,12 @@ module.exports = (toolbox: GluegunToolbox) => {
         choices: readAvailableProfiles(),
         message: `Choose ${labelPrefix}AWS Profile`,
         name: 'profile',
-        required: true
+        required: true,
       })
     ).pipe(
-      map(response => response.profile),
-      map(profile => createProfileCredentials(profile)),
-      switchMap(credentials => {
+      map((response) => response.profile),
+      map((profile) => createProfileCredentials(profile)),
+      switchMap((credentials) => {
         if (!areCredentialsValid(credentials)) {
           print.info('Unknown profile')
           return promptProfile(labelPrefix)
@@ -46,21 +52,21 @@ module.exports = (toolbox: GluegunToolbox) => {
     const ask = (options: PromptOptions) => {
       const name =
         typeof options.name === 'function' ? options.name() : options.name
-      return from(prompt.ask(options)).pipe(map(response => response[name]))
+      return from(prompt.ask(options)).pipe(map((response) => response[name]))
     }
     return ask({
       type: 'input',
       name: 'accessKeyId',
-      message: `${labelPrefix}AWS Access Key ID:`
+      message: `${labelPrefix}AWS Access Key ID:`,
     }).pipe(
-      switchMap(accessKeyId =>
+      switchMap((accessKeyId) =>
         combineLatest([
           of(accessKeyId),
           ask({
             type: 'password',
             name: 'secretAccessKey',
-            message: `${labelPrefix}AWS Secret Access Key:`
-          })
+            message: `${labelPrefix}AWS Secret Access Key:`,
+          }),
         ])
       ),
       map(([accessKeyId, secretAccessKey]) =>
@@ -79,11 +85,11 @@ module.exports = (toolbox: GluegunToolbox) => {
         choices: ['profile', 'explicitly'],
         message: `How do you like to enter ${labelPrefix}credentials?`,
         name: 'type',
-        required: true
+        required: true,
       })
     ).pipe(
-      map(response => response.type),
-      switchMap(type => {
+      map((response) => response.type),
+      switchMap((type) => {
         switch (type) {
           case 'profile':
             return promptProfile(labelPrefix)
@@ -106,9 +112,53 @@ module.exports = (toolbox: GluegunToolbox) => {
         type: 'input',
         name: 'region',
         message: `${labelPrefix}AWS Region`,
-        initial: defaultValue
+        initial: defaultValue,
       })
-    ).pipe(map(response => response.region))
+    ).pipe(map((response) => response.region))
+  }
+
+  const promptTableName = (
+    labelPrefix: string,
+    credentials: Credentials,
+    region: string
+  ): Observable<string> => {
+    labelPrefix = labelPrefix ? labelPrefix + ' ' : ''
+    const client = new DynamoDBClient({
+      region,
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+    })
+    return client.listTables().pipe(
+      switchMap((output) => {
+        if (output.TableNames?.length) {
+          return of(output.TableNames as string[])
+        }
+        return throwError('table names empty')
+      }),
+      switchMap((tables: string[]) =>
+        from(
+          prompt.ask({
+            type: 'select',
+            initial: 0,
+            choices: tables,
+            message: `${labelPrefix} Table Name:`,
+            name: 'tablename',
+            required: true,
+          })
+        )
+      ),
+      map((response) => response.tablename)
+    )
+  }
+  const inputTableName = (labelPrefix: string): Observable<string> => {
+    labelPrefix = labelPrefix ? labelPrefix + ' ' : ''
+    return from(
+      prompt.ask({
+        type: 'input',
+        name: 'tablename',
+        message: `${labelPrefix} Table Name`,
+      })
+    ).pipe(map((response) => response.tablename))
   }
 
   const credentials = (
@@ -159,11 +209,46 @@ module.exports = (toolbox: GluegunToolbox) => {
   const regionChain = (...options: RegionOptions[]): Observable<string> =>
     createChain(options, region)
 
+  const tableName = (options?: TableNameOptions): Observable<string> => {
+    options = deepmerge(defaultTableNameOptions, options || {})
+
+    if (hasOption(options.parameter)) {
+      return of(getOptionValue(options.parameter))
+    }
+    if (hasArgument(options.parameter)) {
+      return of(getArgumentValue(options.parameter))
+    }
+
+    if (!options.interactive) {
+      return of(null)
+    }
+
+    if ('credentials' in options && 'region' in options) {
+      return promptTableName(
+        options.labelPrefix,
+        options.credentials,
+        options.region
+      ).pipe(
+        catchError(() => {
+          print.warning(`Could not automatically read table names.`)
+
+          return inputTableName(options.labelPrefix)
+        })
+      )
+    }
+
+    return inputTableName(options.labelPrefix)
+  }
+  const tableNameChain = (...options: TableNameOptions[]): Observable<string> =>
+    createChain(options, tableName)
+
   toolbox.aws = {
     credentials,
     credentialsChain,
     region,
-    regionChain
+    regionChain,
+    tableName,
+    tableNameChain,
   }
 }
 
@@ -183,18 +268,30 @@ interface RegionOptions {
   defaultValue?: string
 }
 
+interface TableNameOptions {
+  parameter?: string
+  labelPrefix?: string
+  credentials?: Credentials
+  region?: string
+  interactive?: boolean
+}
+
 const defaultCredentialOptions: CredentialOptions = {
   parameters: {
     accessKeyId: 'accessKeyId',
     secretAccessKey: 'secretAccessKey',
-    profile: 'profile'
+    profile: 'profile',
   },
-  interactive: true
+  interactive: true,
 }
 const defaultRegionOptions: RegionOptions = {
   parameter: 'region',
   labelPrefix: '',
-  interactive: true
+  interactive: true,
+}
+const defaultTableNameOptions: TableNameOptions = {
+  labelPrefix: '',
+  interactive: true,
 }
 
 const createProfileCredentials = (profileName: string): Credentials => {
@@ -206,7 +303,7 @@ const createExplicitCredentials = (
 ): Credentials => {
   return new Credentials({
     accessKeyId,
-    secretAccessKey
+    secretAccessKey,
   })
 }
 const areCredentialsValid = (credentials: Credentials): boolean =>
@@ -219,7 +316,7 @@ const createChain = <T, K>(
   let obs = of(null)
 
   // rx recursion - open for better approaches
-  options.forEach(option => {
+  options.forEach((option) => {
     obs = obs.pipe(
       switchMap((res: K) => {
         if (res) {

--- a/packages/cli/src/extensions/aws-extension.ts
+++ b/packages/cli/src/extensions/aws-extension.ts
@@ -210,7 +210,7 @@ module.exports = (toolbox: GluegunToolbox) => {
     createChain(options, region)
 
   const tableName = (options?: TableNameOptions): Observable<string> => {
-    options = deepmerge(defaultTableNameOptions, options || {})
+    options = deepmerge(defaultTableNameOptions, options ?? {})
 
     if (hasOption(options.parameter)) {
       return of(getOptionValue(options.parameter))

--- a/packages/dynamodb/src/client.ts
+++ b/packages/dynamodb/src/client.ts
@@ -6,6 +6,7 @@ import { deleteAll } from "./delete";
 import { copy } from "./copy";
 import { describeTable } from "./describe-table";
 import { map } from "rxjs/operators";
+import { listTables } from "./list-tables";
 
 export class DynamoDBClient {
   private readonly dynamoClient: DynamoDB;
@@ -31,6 +32,9 @@ export class DynamoDBClient {
 
   describeTable(): Observable<DynamoDB.DescribeTableOutput> {
     return describeTable(this.dynamoClient, this.table.tableName);
+  }
+  listTables(): Observable<DynamoDB.ListTablesOutput> {
+    return listTables(this.dynamoClient);
   }
 
   getKeySchema(): Observable<KeySchema> {

--- a/packages/dynamodb/src/list-tables.ts
+++ b/packages/dynamodb/src/list-tables.ts
@@ -1,0 +1,16 @@
+import { throwOnError } from "./operators/throw-on-aws-error";
+import { DynamoDB } from "aws-sdk";
+import { bindCallback, Observable } from "rxjs";
+import { AWSError } from "aws-sdk/lib/error";
+
+export const listTables = (
+  client: DynamoDB
+): Observable<DynamoDB.ListTablesOutput> => {
+  return bindCallback(client.listTables.bind(client) as ListTablesFn)().pipe(
+    throwOnError()
+  );
+};
+
+type ListTablesFn = (
+  callback?: (err: AWSError, data: DynamoDB.Types.ListTablesOutput) => void
+) => any;

--- a/packages/dynamodb/src/models/table.ts
+++ b/packages/dynamodb/src/models/table.ts
@@ -1,5 +1,5 @@
 export interface Table {
-  tableName: string;
+  tableName?: string;
   region: string;
   accessKeyId: string;
   secretAccessKey: string;


### PR DESCRIPTION
Adds ability to prompt table names with type select when listTables returns a valid list.
Fallback to plain string input still exists.