### PR TITLE
fix(dynamodb): fix cross account copy

### DIFF
--- a/packages/dynamodb/src/copy.ts
+++ b/packages/dynamodb/src/copy.ts
@@ -5,8 +5,21 @@ import { throwOnError } from "./operators/throw-on-aws-error";
 
 export const copy = (source: Table, destination: Table) =>
   bindCallback(copyLib as (p: any, cb: (error, result) => void) => void)({
-    config: source,
-    source,
-    destination,
+    source: {
+      tableName: source.tableName,
+      config: {
+        accessKeyId: source.accessKeyId,
+        secretAccessKey: source.secretAccessKey,
+        region: source.region,
+      },
+    },
+    destination: {
+      tableName: destination.tableName,
+      config: {
+        accessKeyId: destination.accessKeyId,
+        secretAccessKey: destination.secretAccessKey,
+        region: destination.region,
+      },
+    },
     log: true,
   }).pipe(throwOnError());


### PR DESCRIPTION
Currently sync is only supported in the account and region of the source table.

This PR configures `copy-dynamodb-table` to use different credentials for source & destination