### PR TITLE
fix(dynamodb): fix purge when key is number

### DIFF
--- a/packages/dynamodb/src/delete.ts
+++ b/packages/dynamodb/src/delete.ts
@@ -45,7 +45,7 @@ const convertItemToKey = (item: any, keySchema: KeySchema) => {
   Object.keys(keySchema).forEach((keyName) => {
     const type = keySchema[keyName];
     key[keyName] = {};
-    key[keyName][type] = item[keyName];
+    key[keyName][type] = String(item[keyName]);
   });
   return key;
 };


### PR DESCRIPTION
key values for types S, N & B always need to be of type string no matter of the actual type

Refs: #7